### PR TITLE
Implement mutable copy functionality for storing pending changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "mobx": "^5.15.1"
   },
   "devDependencies": {
+    "@types/clone": "^2.1.0",
     "@types/deep-equal": "^1.0.1",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.12",
@@ -101,6 +102,7 @@
   },
   "dependencies": {
     "bind-decorator": "^1.0.11",
+    "clone": "^2.1.2",
     "deep-equal": "^2.0.5",
     "mobx-react": "^7.0.5",
     "react": "^17.0.1",

--- a/src/indexable-repository.ts
+++ b/src/indexable-repository.ts
@@ -414,7 +414,7 @@ export abstract class IndexableRepository<TEntity, TId = string, TBatchId = stri
         if (!this.mutableCopyBatches.has(batchId)) {
             this.mutableCopyBatches.set(batchId, new Map<TId, TEntity>());
         }
-        return this.mutableCopyBatches.get(batchId)
+        return this.mutableCopyBatches.get(batchId);
     }
 
     /** @inheritdoc */

--- a/src/paginated-searchable-repository.ts
+++ b/src/paginated-searchable-repository.ts
@@ -177,7 +177,7 @@ export interface PaginatedSearchable<TQuery, TEntity> extends Searchable<TQuery,
 
     /**
      * Checks whether a specified query was out of bounds earlier, in the specified range.
-     * 
+     *
      * @param query The query to check.
      * @param pagination The pagination to check.
      */
@@ -250,8 +250,8 @@ interface ListenerSpecification<TQuery> {
  * }
  * ```
  */
-export abstract class PaginatedSearchableRepository<TQuery, TEntity, TId = string>
-    extends IndexableRepository<TEntity, TId>
+export abstract class PaginatedSearchableRepository<TQuery, TEntity, TId = string, TBatchId = string>
+    extends IndexableRepository<TEntity, TId, TBatchId>
     implements PaginatedSearchable<TQuery, TEntity> {
 
     constructor() {

--- a/src/searchable-repository.ts
+++ b/src/searchable-repository.ts
@@ -48,7 +48,7 @@ export interface Searchable<TQuery, TEntity> {
      *     class MyComponent extends React.Component<{ id: string }> {
      *         // The current query as entered by the user.
      *         @observable private search = 0;
-     * 
+     *
      *         // Get access to the repository.
      *         // For example using dependency-injection, context or props.
      *         private myRepository!: MyRepository;
@@ -191,7 +191,8 @@ export interface Searchable<TQuery, TEntity> {
  * }
  * ```
  */
-export abstract class SearchableRepository<TQuery, TEntity, TId = string> extends IndexableRepository<TEntity, TId>
+export abstract class SearchableRepository<TQuery, TEntity, TId = string, TBatchId = string>
+    extends IndexableRepository<TEntity, TId, TBatchId>
     implements Searchable<TQuery, TEntity> {
 
     constructor() {

--- a/test/test-indexable-repository.ts
+++ b/test/test-indexable-repository.ts
@@ -222,6 +222,11 @@ describe("IndexableRepository", () => {
                             })
                     );
 
+                    test.each(["entity1", "entity2"])(
+                        "the immutable original %p is not mutated",
+                        (id) => expect(repository.byId(id)).toStrictEqual({ id, value: `value-${id}` })
+                    );
+
                     describe("and discarding some changes", () => {
                         beforeEach(() => {
                             repository.discardMutableCopy("batch1", "entity1");
@@ -241,6 +246,11 @@ describe("IndexableRepository", () => {
                                     id: entityId,
                                     value: batchId + entityId
                                 })
+                        );
+
+                        test.each(["entity1", "entity2"])(
+                            "the immutable original %p is present and not mutated",
+                            (id) => expect(repository.byId(id)).toStrictEqual({ id, value: `value-${id}` })
                         );
                     });
                 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,6 +677,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/clone@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/clone/-/clone-2.1.0.tgz#cb888a3fe5319275b566ae3a9bc606e310c533d4"
+  integrity sha512-d/aS/lPOnUSruPhgNtT8jW39fHRVTLQy9sodysP1kkG8EdAtdZu1vt8NJaYA8w/6Z9j8izkAsx1A/yJhcYR1CA==
+
 "@types/deep-equal@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-1.0.1.tgz#71cfabb247c22bcc16d536111f50c0ed12476b03"
@@ -1265,6 +1270,11 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
Add new methods to the interface of indexable repository which provides a way to store any number of additional instances of an entity for the purpose of editable forms.